### PR TITLE
Update IoT Logic OpenAPI spec: fix contradictions, add missing endpoints, improve descriptions

### DIFF
--- a/docs/resources/api-reference/IoT_Logic.json
+++ b/docs/resources/api-reference/IoT_Logic.json
@@ -40,7 +40,7 @@
       "post": {
         "tags": ["Flow"],
         "summary": "flowCreate",
-        "description": "Create a new flow. Nodes and edges can be included in the creation request or added later via `endpointCreate`. The request body must nest the flow object inside a `flow` key: `{\"flow\": <FlowDraft>}`. Returns the ID of the created flow.",
+        "description": "Create a new data processing flow with nodes and connections. Flows define how data moves from devices through transformation stages to output destinations. Each flow requires at least one Data Source node and one Output Endpoint node. You can create flows with nodes and edges in a single request or add nodes later using the endpoint management API.",
         "operationId": "flowCreate",
         "requestBody": {
           "content": {
@@ -79,7 +79,7 @@
       "get": {
         "tags": ["Flow"],
         "summary": "flowRead",
-        "description": "Retrieve the complete configuration of a single flow: all nodes, edges, positions, and runtime fields (`enabled`, `default_flow`). Use this when you need the full graph structure. For a lightweight listing of all flows with metadata only, use `flowList`.",
+        "description": "Retrieve complete flow configuration including all nodes, edges, and metadata. Returns the flow structure with node positions, connections, and enabled status. Use this endpoint to inspect flow architecture or retrieve configuration for duplication.",
         "operationId": "flowRead",
         "parameters": [
           {
@@ -130,7 +130,7 @@
       "post": {
         "tags": ["Flow"],
         "summary": "flowUpdate",
-        "description": "Replace the entire configuration of an existing flow. Send the complete flow object — nodes and edges omitted from the request are deleted. The request body must nest the flow object inside a `flow` key: `{\"flow\": <Flow>}`. Changes apply immediately to enabled flows. Returns the flow ID.",
+        "description": "Update an existing flow's configuration. Requires the complete flow object including all nodes and edges. To modify individual nodes without affecting the entire flow, use the endpoint management API. Changes take effect immediately for enabled flows.",
         "operationId": "flowUpdate",
         "requestBody": {
           "content": {
@@ -169,7 +169,7 @@
       "post": {
         "tags": ["Flow"],
         "summary": "flowDelete",
-        "description": "Permanently delete a flow. All devices assigned to this flow automatically revert to the account's default flow. Cannot be undone. To pause processing without losing the flow configuration, use `flowUpdate` with `enabled: false` instead.",
+        "description": "Permanently delete a flow and stop its data processing pipeline. Devices assigned to this flow will automatically revert to the default flow in your account. This action cannot be undone. To temporarily stop processing without reassigning devices, disable the flow using the update endpoint instead.",
         "operationId": "flowDelete",
         "requestBody": {
           "content": {
@@ -209,7 +209,7 @@
       "get": {
         "tags": ["Flow"],
         "summary": "flowList",
-        "description": "List all flows in the user account. Returns summary metadata for each flow: `id`, `title`, `description`, `enabled`, `default_flow`, last modified timestamp, and assigned device count. Does not include node or edge data — use `flowRead` to retrieve the full graph for a specific flow.",
+        "description": "List all flows in the user account. Returns flow IDs and titles only. Use the read endpoint to retrieve complete flow details including nodes and configuration.",
         "operationId": "flowList",
         "responses": {
           "200": {
@@ -253,7 +253,7 @@
       "get": {
         "tags": ["Flow"],
         "summary": "flowExport",
-        "description": "Export a flow as a portable structure that can be passed directly to `flowCreate` to duplicate it or import it into another account. Returns only the flow graph (title, description, nodes, edges) — runtime and identity fields (`id`, `enabled`, `default_flow`) are stripped. Unlike `flowRead`, the response `value` is not wrapped in a `flow` envelope and is ready to use as a `flowCreate` request body.",
+        "description": "Export a flow as a reusable template without instance-specific metadata. Unlike the read endpoint which retrieves the complete operational state of a flow, export returns only the flow structure (nodes, edges, title, description) suitable for creating duplicate flows or transferring configurations between accounts. The exported template excludes flow ID, enabled status, and default flow designation, making it ready for use with the create endpoint.",
         "operationId": "flowExport",
         "parameters": [
           {
@@ -303,7 +303,7 @@
       "get": {
         "tags": ["Flow"],
         "summary": "sourceMappingList",
-        "description": "List all device-to-flow assignments in the user account with pagination. Each record identifies a device, the flow it is assigned to, and the specific Data Source node within that flow that ingests it. Supports `offset` and `limit` for large device fleets (`limit` max: 100 000, default: 10 000).",
+        "description": "List all device-to-flow assignments in the user account. Shows which devices are currently assigned to which flows and their corresponding Data Source nodes. Returns device information including title, model, and the flow configuration processing its data. Use this endpoint to audit device assignments, identify unassigned devices, or verify flow coverage across your device fleet. Supports pagination for accounts with large device inventories.",
         "operationId": "sourceMappingList",
         "parameters": [
           {
@@ -374,7 +374,7 @@
       "post": {
         "tags": ["Node"],
         "summary": "endpointCreate",
-        "description": "Create a new output endpoint (IotEndpoint) in the user account. Output endpoints are reusable, account-level output destinations — either the Navixy platform (`output_default`) or an external MQTT broker (`output_mqtt_client`). They are distinct from flow graph nodes: an IotEndpoint is stored once at the account level and referenced by Output Endpoint nodes in flows via `output_endpoint_id`. The `type` field acts as a discriminator that determines the required shape of `properties`. Wrap the payload in an `endpoint` key: `{\"endpoint\": <IotEndpointDraft>}`. Returns the ID of the created endpoint.",
+        "description": "Create a new node within a flow. Supports all node types existing in IoT Logic. The node type is specified in the request body's type field. ",
         "operationId": "endpointCreate",
         "requestBody": {
           "content": {
@@ -412,7 +412,7 @@
       "post": {
         "tags": ["Node"],
         "summary": "endpointRead",
-        "description": "Retrieve the full configuration of a single output endpoint by ID, including its `type`, `status`, `description`, and `properties` (MQTT connection details for `output_mqtt_client` endpoints). Use `endpointList` to enumerate endpoints and obtain their IDs.",
+        "description": "Retrieve detailed configuration for a specific node. Returns complete node data including type-specific configuration, position, and enabled status. Use this endpoint to inspect individual node configuration without retrieving the entire flow.",
         "operationId": "endpointRead",
         "requestBody": {
           "content": {
@@ -470,7 +470,7 @@
       "post": {
         "tags": ["Node"],
         "summary": "endpointUpdate",
-        "description": "Replace the full configuration of an existing output endpoint. Requires the complete IotEndpoint object including `id`, wrapped in an `endpoint` key: `{\"endpoint\": <IotEndpoint>}`. Changes apply immediately to all flows that reference this endpoint.",
+        "description": "Update an existing node configuration. Requires the complete node object including all required fields for the node type. Changes to nodes in enabled flows take effect immediately and may impact active data processing. ",
         "operationId": "endpointUpdate",
         "requestBody": {
           "content": {
@@ -508,7 +508,7 @@
       "post": {
         "tags": ["Node"],
         "summary": "endpointDelete",
-        "description": "Permanently delete an output endpoint from the user account. Any Output Endpoint nodes in flows that reference this endpoint via `output_endpoint_id` will lose their output target — disable or update those flows before deleting. Cannot be undone.",
+        "description": "Permanently delete a node from accoun. Automatically removes all edges connected to this node. Deleting critical nodes (Data Source or Output Endpoint) from enabled flows will interrupt data processing. Verify flow integrity after deletion.",
         "operationId": "endpointDelete",
         "requestBody": {
           "content": {
@@ -815,7 +815,7 @@
       "post": {
         "tags": ["Node"],
         "summary": "endpointList",
-        "description": "List all output endpoints in the user account. Returns a trimmed summary for each: `id`, `title`, `type`, and `description`. Use `endpointRead` to retrieve the full configuration including MQTT connection properties for a specific endpoint.",
+        "description": "List all nodes across all flows in the user account. Returns complete node configurations including type, data, and position for each node. To retrieve nodes for a specific flow, use the flow read endpoint instead.",
         "operationId": "endpointList",
         "requestBody": {
           "content": {

--- a/docs/resources/api-reference/IoT_Logic.json
+++ b/docs/resources/api-reference/IoT_Logic.json
@@ -4,7 +4,7 @@
     "version": "1.0.0",
     "title": "Navixy IoT Logic API",
     "summary": "API calls for Flow and Node management",
-    "description": "This is an API reference for Flow and Node management in Navixy IoT Logic. Use these endpoints to create and configure data processing flows, manage nodes and their connections, assign devices to flows, and export or import flow configurations.",
+    "description": "Navixy IoT Logic API. Use these endpoints to build and manage data processing pipelines (flows) that transform telemetry from IoT devices into actions and outputs. A flow is a directed graph of nodes — data sources, attribute transforms, logic branches, device actions, webhooks, and output endpoints. This spec also covers output endpoint management, device-source assignment queries, and flow validation.",
     "contact": {
       "name": "Navixy support",
       "email": "support@navixy.com",
@@ -28,19 +28,11 @@
   "tags": [
     {
       "name": "Flow",
-      "description": "Operations for managing data flows"
+      "description": "Operations for creating, reading, updating, and deleting flows. Also covers flow validation, system-provided templates, and device source queries — all resources under the /iot/logic/flow/ path."
     },
     {
       "name": "Node",
-      "description": "Operations for managing flow nodes (endpoints)"
-    },
-    {
-      "name": "Template",
-      "description": "Operations for reading flow templates"
-    },
-    {
-      "name": "Sources",
-      "description": "Operations for querying flow source assignments"
+      "description": "Operations for managing output endpoints (IotEndpoints) — reusable, account-level output destinations (Navixy platform or external MQTT broker) that are referenced by Output Endpoint nodes inside flows."
     }
   ],
   "paths": {
@@ -48,7 +40,7 @@
       "post": {
         "tags": ["Flow"],
         "summary": "flowCreate",
-        "description": "Create a new data processing flow with nodes and connections. Flows define how data moves from devices through transformation stages to output destinations. Each flow requires at least one Data Source node and one Output Endpoint node. You can create flows with nodes and edges in a single request or add nodes later using the endpoint management API.",
+        "description": "Create a new flow. Nodes and edges can be included in the creation request or added later via `endpointCreate`. The request body must nest the flow object inside a `flow` key: `{\"flow\": <FlowDraft>}`. Returns the ID of the created flow.",
         "operationId": "flowCreate",
         "requestBody": {
           "content": {
@@ -84,7 +76,7 @@
       "get": {
         "tags": ["Flow"],
         "summary": "flowRead",
-        "description": "Retrieve complete flow configuration including all nodes, edges, and metadata. Returns the flow structure with node positions, connections, and enabled status. Use this endpoint to inspect flow architecture or retrieve configuration for duplication.",
+        "description": "Retrieve the complete configuration of a single flow: all nodes, edges, positions, and runtime fields (`enabled`, `default_flow`). Use this when you need the full graph structure. For a lightweight listing of all flows with metadata only, use `flowList`.",
         "operationId": "flowRead",
         "parameters": [
           {
@@ -135,7 +127,7 @@
       "post": {
         "tags": ["Flow"],
         "summary": "flowUpdate",
-        "description": "Update an existing flow's configuration. Requires the complete flow object including all nodes and edges. To modify individual nodes without affecting the entire flow, use the endpoint management API. Changes take effect immediately for enabled flows.",
+        "description": "Replace the entire configuration of an existing flow. Send the complete flow object — nodes and edges omitted from the request are deleted. The request body must nest the flow object inside a `flow` key: `{\"flow\": <Flow>}`. Changes apply immediately to enabled flows. Returns the flow ID.",
         "operationId": "flowUpdate",
         "requestBody": {
           "content": {
@@ -174,7 +166,7 @@
       "post": {
         "tags": ["Flow"],
         "summary": "flowDelete",
-        "description": "Permanently delete a flow and stop its data processing pipeline. Devices assigned to this flow will automatically revert to the default flow in your account. This action cannot be undone. To temporarily stop processing without reassigning devices, disable the flow using the update endpoint instead.",
+        "description": "Permanently delete a flow. All devices assigned to this flow automatically revert to the account's default flow. Cannot be undone. To pause processing without losing the flow configuration, use `flowUpdate` with `enabled: false` instead.",
         "operationId": "flowDelete",
         "requestBody": {
           "content": {
@@ -221,7 +213,7 @@
       "get": {
         "tags": ["Flow"],
         "summary": "flowList",
-        "description": "List all flows in the user account. Returns flow IDs and titles only. Use the read endpoint to retrieve complete flow details including nodes and configuration.",
+        "description": "List all flows in the user account. Returns summary metadata for each flow: `id`, `title`, `description`, `enabled`, `default_flow`, last modified timestamp, and assigned device count. Does not include node or edge data — use `flowRead` to retrieve the full graph for a specific flow.",
         "operationId": "flowList",
         "responses": {
           "200": {
@@ -265,7 +257,7 @@
       "get": {
         "tags": ["Flow"],
         "summary": "flowExport",
-        "description": "Export a flow as a reusable template without instance-specific metadata. Unlike the read endpoint which retrieves the complete operational state of a flow, export returns only the flow structure (nodes, edges, title, description) suitable for creating duplicate flows or transferring configurations between accounts. The exported template excludes flow ID, enabled status, and default flow designation, making it ready for use with the create endpoint.",
+        "description": "Export a flow as a portable structure that can be passed directly to `flowCreate` to duplicate it or import it into another account. Returns only the flow graph (title, description, nodes, edges) — runtime and identity fields (`id`, `enabled`, `default_flow`) are stripped. Unlike `flowRead`, the response `value` is not wrapped in a `flow` envelope and is ready to use as a `flowCreate` request body.",
         "operationId": "flowExport",
         "parameters": [
           {
@@ -315,7 +307,7 @@
       "get": {
         "tags": ["Flow"],
         "summary": "sourceMappingList",
-        "description": "List all device-to-flow assignments in the user account. Shows which devices are currently assigned to which flows and their corresponding Data Source nodes. Returns device information including title, model, and the flow configuration processing its data. Use this endpoint to audit device assignments, identify unassigned devices, or verify flow coverage across your device fleet. Supports pagination for accounts with large device inventories.",
+        "description": "List all device-to-flow assignments in the user account with pagination. Each record identifies a device, the flow it is assigned to, and the specific Data Source node within that flow that ingests it. Supports `offset` and `limit` for large device fleets (`limit` max: 100 000, default: 10 000).",
         "operationId": "sourceMappingList",
         "parameters": [
           {
@@ -386,7 +378,7 @@
       "post": {
         "tags": ["Node"],
         "summary": "endpointCreate",
-        "description": "Create a new node within a flow. Supports all node types existing in IoT Logic. The node type is specified in the request body's type field. ",
+        "description": "Create a new output endpoint (IotEndpoint) in the user account. Output endpoints are reusable, account-level output destinations — either the Navixy platform (`output_default`) or an external MQTT broker (`output_mqtt_client`). They are distinct from flow graph nodes: an IotEndpoint is stored once at the account level and referenced by Output Endpoint nodes in flows via `output_endpoint_id`. The `type` field acts as a discriminator that determines the required shape of `properties`. Wrap the payload in an `endpoint` key: `{\"endpoint\": <IotEndpointDraft>}`. Returns the ID of the created endpoint.",
         "operationId": "endpointCreate",
         "requestBody": {
           "content": {
@@ -424,7 +416,7 @@
       "post": {
         "tags": ["Node"],
         "summary": "endpointRead",
-        "description": "Retrieve detailed configuration for a specific node. Returns complete node data including type-specific configuration, position, and enabled status. Use this endpoint to inspect individual node configuration without retrieving the entire flow.",
+        "description": "Retrieve the full configuration of a single output endpoint by ID, including its `type`, `status`, `description`, and `properties` (MQTT connection details for `output_mqtt_client` endpoints). Use `endpointList` to enumerate endpoints and obtain their IDs.",
         "operationId": "endpointRead",
         "requestBody": {
           "content": {
@@ -482,7 +474,7 @@
       "post": {
         "tags": ["Node"],
         "summary": "endpointUpdate",
-        "description": "Update an existing node configuration. Requires the complete node object including all required fields for the node type. Changes to nodes in enabled flows take effect immediately and may impact active data processing. ",
+        "description": "Replace the full configuration of an existing output endpoint. Requires the complete IotEndpoint object including `id`, wrapped in an `endpoint` key: `{\"endpoint\": <IotEndpoint>}`. Changes apply immediately to all flows that reference this endpoint.",
         "operationId": "endpointUpdate",
         "requestBody": {
           "content": {
@@ -520,7 +512,7 @@
       "post": {
         "tags": ["Node"],
         "summary": "endpointDelete",
-        "description": "Permanently delete a node from accoun. Automatically removes all edges connected to this node. Deleting critical nodes (Data Source or Output Endpoint) from enabled flows will interrupt data processing. Verify flow integrity after deletion.",
+        "description": "Permanently delete an output endpoint from the user account. Any Output Endpoint nodes in flows that reference this endpoint via `output_endpoint_id` will lose their output target — disable or update those flows before deleting. Cannot be undone.",
         "operationId": "endpointDelete",
         "requestBody": {
           "content": {
@@ -560,7 +552,7 @@
       "get": {
         "tags": ["Flow"],
         "summary": "flowSchema",
-        "description": "Retrieve the JSON Schema document that describes the structure of a valid flow object. Use this to validate a flow configuration client-side before submitting it to the create or update endpoint.",
+        "description": "Return the server-side JSON Schema used to validate flow objects submitted to `flowCreate` and `flowUpdate`. Clients and LLM agents can fetch this schema to validate a flow structure locally before making a write request. The schema is opaque and may change between server versions.",
         "operationId": "flowSchema",
         "responses": {
           "200": {
@@ -599,9 +591,9 @@
     },
     "/iot/logic/flow/template/read": {
       "get": {
-        "tags": ["Template"],
+        "tags": ["Flow"],
         "summary": "flowTemplateRead",
-        "description": "Retrieve a single flow template by its ID. Templates are pre-built flow configurations that can be instantiated as new flows.",
+        "description": "Retrieve a single system-provided flow template by its ID. A template is a pre-built flow graph (nodes + edges) that can be instantiated as a new flow by passing its structure to `flowCreate`. Use `flowTemplateList` to discover available template IDs and their descriptions.",
         "operationId": "flowTemplateRead",
         "parameters": [
           {
@@ -651,9 +643,9 @@
     },
     "/iot/logic/flow/template/list": {
       "get": {
-        "tags": ["Template"],
+        "tags": ["Flow"],
         "summary": "flowTemplateList",
-        "description": "List all available flow templates. Returns template IDs, titles, and node structures. Use the template/read endpoint to retrieve a single template in full detail.",
+        "description": "List all system-provided flow templates available to the user. Each item includes the template ID, title, description, and the pre-configured node and edge graph. To create a flow from a template, pass the template's nodes and edges to `flowCreate`.",
         "operationId": "flowTemplateList",
         "responses": {
           "200": {
@@ -695,9 +687,9 @@
     },
     "/iot/logic/flow/sources/list": {
       "get": {
-        "tags": ["Sources"],
+        "tags": ["Flow"],
         "summary": "flowSourcesList",
-        "description": "Retrieve the list of device source IDs feeding a specific flow. For `flow_id=0` (the default flow), returns all trackers in the user account that are not explicitly assigned to any custom flow. For a specific flow ID, returns the device IDs explicitly linked to that flow as sources.",
+        "description": "Return the device source IDs currently feeding a specific flow. Pass `flow_id=0` to query the default flow — returns all trackers in the account not explicitly assigned to any custom flow. Pass a specific flow ID to get only the device IDs explicitly linked to that flow. Use this to determine which devices a flow processes before modifying source assignments.",
         "operationId": "flowSourcesList",
         "parameters": [
           {
@@ -753,9 +745,9 @@
     },
     "/iot/logic/flow/sources/attribute/list": {
       "get": {
-        "tags": ["Sources"],
+        "tags": ["Flow"],
         "summary": "flowSourcesAttributeList",
-        "description": "Retrieve the data attributes (parameters) available from the specified devices. Used by the flow editor to discover which fields can be referenced in node expressions. When `include_only_iot_flow_attributes` is `true`, returns only attributes emitted by IoT Logic flows; otherwise returns all attributes (raw device parameters and computed ones).",
+        "description": "Return the telemetry attributes available from the specified devices, for use when authoring expressions in Initiate Attributes or Logic nodes. Pass one or more `source_ids` as repeated query parameters. Set `include_only_iot_flow_attributes=true` to return only attributes that IoT Logic flows have computed and emitted; set it to `false` to return all attributes including raw device parameters.",
         "operationId": "flowSourcesAttributeList",
         "parameters": [
           {
@@ -827,7 +819,7 @@
       "post": {
         "tags": ["Node"],
         "summary": "endpointList",
-        "description": "List all nodes across all flows in the user account. Returns complete node configurations including type, data, and position for each node. To retrieve nodes for a specific flow, use the flow read endpoint instead.",
+        "description": "List all output endpoints in the user account. Returns a trimmed summary for each: `id`, `title`, `type`, and `description`. Use `endpointRead` to retrieve the full configuration including MQTT connection properties for a specific endpoint.",
         "operationId": "endpointList",
         "requestBody": {
           "content": {

--- a/docs/resources/api-reference/IoT_Logic.json
+++ b/docs/resources/api-reference/IoT_Logic.json
@@ -4,7 +4,7 @@
     "version": "1.0.0",
     "title": "Navixy IoT Logic API",
     "summary": "API calls for Flow and Node management",
-    "description": "Navixy IoT Logic API. Use these endpoints to build and manage data processing pipelines (flows) that transform telemetry from IoT devices into actions and outputs. A flow is a directed graph of nodes — data sources, attribute transforms, logic branches, device actions, webhooks, and output endpoints. This spec also covers output endpoint management, device-source assignment queries, and flow validation.",
+    "description": "This is an API reference for Flow and Node management in Navixy IoT Logic. Use these endpoints to create and configure data processing flows, manage nodes and their connections, assign devices to flows, and export or import flow configurations.",
     "contact": {
       "name": "Navixy support",
       "email": "support@navixy.com",

--- a/docs/resources/api-reference/IoT_Logic.json
+++ b/docs/resources/api-reference/IoT_Logic.json
@@ -209,7 +209,7 @@
       "get": {
         "tags": ["Flow"],
         "summary": "flowList",
-        "description": "List all flows in the user account. Returns flow IDs and titles only. Use the read endpoint to retrieve complete flow details including nodes and configuration.",
+        "description": "List all flows in the user account. Returns summary metadata for each flow (id, title, description, enabled status, default_flow flag, last modified timestamp, and device count). Use the read endpoint to retrieve complete flow details including nodes and configuration.",
         "operationId": "flowList",
         "responses": {
           "200": {
@@ -815,7 +815,7 @@
       "post": {
         "tags": ["Node"],
         "summary": "endpointList",
-        "description": "List all nodes across all flows in the user account. Returns complete node configurations including type, data, and position for each node. To retrieve nodes for a specific flow, use the flow read endpoint instead.",
+        "description": "List all output endpoints in the user account. Returns a summary view for each endpoint: id, title, type, and description. Use endpointRead to retrieve the full configuration including connection properties for a specific endpoint.",
         "operationId": "endpointList",
         "requestBody": {
           "content": {

--- a/docs/resources/api-reference/IoT_Logic.json
+++ b/docs/resources/api-reference/IoT_Logic.json
@@ -31,8 +31,16 @@
       "description": "Operations for managing data flows"
     },
     {
-      "name": "Node", 
+      "name": "Node",
       "description": "Operations for managing flow nodes (endpoints)"
+    },
+    {
+      "name": "Template",
+      "description": "Operations for reading flow templates"
+    },
+    {
+      "name": "Sources",
+      "description": "Operations for querying flow source assignments"
     }
   ],
   "paths": {
@@ -149,7 +157,7 @@
         },
         "responses": {
           "200": {
-            "$ref": "#/components/responses/OK"
+            "$ref": "#/components/responses/EntityCreatedResponse"
           },
           "default": {
             "$ref": "#/components/responses/ResponseError"
@@ -234,22 +242,7 @@
                       "description": "List of user's flows",
                       "readOnly": true,
                       "items": {
-                        "type": "object",
-                        "properties": {
-                          "id": {
-                            "type": "integer",
-                            "description": "Flow ID",
-                            "readOnly": true,
-                            "example": 1234
-                          },
-                          "title": {
-                            "type": "string",
-                            "description": "Flow name",
-                            "readOnly": true,
-                            "example": "Super flow"
-                          }
-                        },
-                        "readOnly": true
+                        "$ref": "#/components/schemas/IotFlowInfo"
                       }
                     }
                   }
@@ -347,24 +340,32 @@
         ],
         "responses": {
           "200": {
-            "description": "success",
+            "description": "Successful response",
             "content": {
               "application/json": {
                 "schema": {
-                  "example": {
-                    "list": [
-                      {
-                        "device_title": "Emulator",
-                        "model_code": "navixy_ngp",
-                        "device_id": "123456789",
-                        "flow_id": 1,
-                        "flow_title": "Default flow",
-                        "node_id": 1,
-                        "node_title": "Source node"
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "`true` if request finished successfully.",
+                      "readOnly": true,
+                      "example": true
+                    },
+                    "list": {
+                      "type": "array",
+                      "description": "Device-to-flow mapping records",
+                      "readOnly": true,
+                      "items": {
+                        "$ref": "#/components/schemas/IotLogicFlowDeviceMapping"
                       }
-                    ],
-                    "count": 1,
-                    "success": true
+                    },
+                    "count": {
+                      "type": "integer",
+                      "description": "Total number of mapping records matching the query",
+                      "readOnly": true,
+                      "example": 1
+                    }
                   }
                 }
               }
@@ -555,6 +556,273 @@
         ]
       }
     },
+    "/iot/logic/flow/schema": {
+      "get": {
+        "tags": ["Flow"],
+        "summary": "flowSchema",
+        "description": "Retrieve the JSON Schema document that describes the structure of a valid flow object. Use this to validate a flow configuration client-side before submitting it to the create or update endpoint.",
+        "operationId": "flowSchema",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "`true` if request finished successfully.",
+                      "readOnly": true,
+                      "example": true
+                    },
+                    "value": {
+                      "type": "object",
+                      "description": "A JSON Schema document describing the valid structure of a flow. Treat as opaque — the schema may evolve between API versions.",
+                      "readOnly": true
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/ResponseError"
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/iot/logic/flow/template/read": {
+      "get": {
+        "tags": ["Template"],
+        "summary": "flowTemplateRead",
+        "description": "Retrieve a single flow template by its ID. Templates are pre-built flow configurations that can be instantiated as new flows.",
+        "operationId": "flowTemplateRead",
+        "parameters": [
+          {
+            "name": "flow_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Template ID",
+              "example": 1
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "`true` if request finished successfully.",
+                      "readOnly": true,
+                      "example": true
+                    },
+                    "value": {
+                      "$ref": "#/components/schemas/IotFlowTemplate"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/ResponseError"
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/iot/logic/flow/template/list": {
+      "get": {
+        "tags": ["Template"],
+        "summary": "flowTemplateList",
+        "description": "List all available flow templates. Returns template IDs, titles, and node structures. Use the template/read endpoint to retrieve a single template in full detail.",
+        "operationId": "flowTemplateList",
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "`true` if request finished successfully.",
+                      "readOnly": true,
+                      "example": true
+                    },
+                    "list": {
+                      "type": "array",
+                      "description": "Available flow templates",
+                      "readOnly": true,
+                      "items": {
+                        "$ref": "#/components/schemas/IotFlowTemplate"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/ResponseError"
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/iot/logic/flow/sources/list": {
+      "get": {
+        "tags": ["Sources"],
+        "summary": "flowSourcesList",
+        "description": "Retrieve the list of device source IDs feeding a specific flow. For `flow_id=0` (the default flow), returns all trackers in the user account that are not explicitly assigned to any custom flow. For a specific flow ID, returns the device IDs explicitly linked to that flow as sources.",
+        "operationId": "flowSourcesList",
+        "parameters": [
+          {
+            "name": "flow_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "description": "Flow ID. Use 0 to query the default flow.",
+              "example": 0
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "`true` if request finished successfully.",
+                      "readOnly": true,
+                      "example": true
+                    },
+                    "value": {
+                      "type": "array",
+                      "description": "Device source IDs feeding the flow.",
+                      "readOnly": true,
+                      "items": {
+                        "type": "integer"
+                      },
+                      "example": [123456, 789012]
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/ResponseError"
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
+    "/iot/logic/flow/sources/attribute/list": {
+      "get": {
+        "tags": ["Sources"],
+        "summary": "flowSourcesAttributeList",
+        "description": "Retrieve the data attributes (parameters) available from the specified devices. Used by the flow editor to discover which fields can be referenced in node expressions. When `include_only_iot_flow_attributes` is `true`, returns only attributes emitted by IoT Logic flows; otherwise returns all attributes (raw device parameters and computed ones).",
+        "operationId": "flowSourcesAttributeList",
+        "parameters": [
+          {
+            "name": "source_ids",
+            "in": "query",
+            "required": true,
+            "style": "form",
+            "explode": true,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "integer"
+              },
+              "minItems": 1,
+              "description": "Device source IDs to query attributes for.",
+              "example": [123456, 789012]
+            }
+          },
+          {
+            "name": "include_only_iot_flow_attributes",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "boolean",
+              "description": "When true, returns only IoT Logic flow-emitted attributes. When false, returns all attributes including raw device parameters.",
+              "example": false
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "success": {
+                      "type": "boolean",
+                      "description": "`true` if request finished successfully.",
+                      "readOnly": true,
+                      "example": true
+                    },
+                    "list": {
+                      "type": "array",
+                      "description": "Attributes available from the specified devices.",
+                      "readOnly": true,
+                      "items": {
+                        "$ref": "#/components/schemas/TrackerAttribute"
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "default": {
+            "$ref": "#/components/responses/ResponseError"
+          }
+        },
+        "security": [
+          {
+            "api_key": []
+          }
+        ]
+      }
+    },
     "/iot/logic/flow/endpoint/list": {
       "post": {
         "tags": ["Node"],
@@ -589,7 +857,7 @@
                       "description": "List of user's endpoints",
                       "readOnly": true,
                       "items": {
-                        "$ref": "#/components/schemas/IotEndpoint"
+                        "$ref": "#/components/schemas/IotEndpointResponse"
                       }
                     }
                   }
@@ -808,6 +1076,92 @@
             }
           }
         }
+      },
+      "IotFlowInfo": {
+        "type": "object",
+        "description": "Flow summary as returned by the flow/list endpoint.",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Flow ID",
+            "readOnly": true,
+            "example": 1234
+          },
+          "title": {
+            "type": "string",
+            "description": "Flow name",
+            "readOnly": true,
+            "example": "Super flow"
+          },
+          "description": {
+            "type": ["string", "null"],
+            "description": "Flow description",
+            "readOnly": true,
+            "example": null
+          },
+          "enabled": {
+            "type": "boolean",
+            "description": "Whether the flow is currently enabled",
+            "readOnly": true,
+            "example": true
+          },
+          "default_flow": {
+            "type": "boolean",
+            "description": "Whether this is the account's default flow",
+            "readOnly": true,
+            "example": false
+          },
+          "modified": {
+            "type": "string",
+            "format": "date-time",
+            "description": "Timestamp of the last modification",
+            "readOnly": true,
+            "example": "2024-01-15T10:30:00Z"
+          },
+          "devices_count": {
+            "type": "integer",
+            "description": "Number of devices currently assigned to this flow",
+            "readOnly": true,
+            "example": 42
+          }
+        }
+      },
+      "IotFlowTemplate": {
+        "type": "object",
+        "description": "Pre-built flow template available for instantiation as a new flow.",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "description": "Template ID",
+            "readOnly": true,
+            "example": 1
+          },
+          "title": {
+            "type": "string",
+            "description": "Template name",
+            "example": "Basic processing flow"
+          },
+          "description": {
+            "type": ["string", "null"],
+            "description": "Template description",
+            "example": "A simple flow for standard telemetry processing."
+          },
+          "nodes": {
+            "type": "array",
+            "description": "Nodes pre-configured in this template.",
+            "items": {
+              "$ref": "#/components/schemas/Node"
+            }
+          },
+          "edges": {
+            "type": "array",
+            "description": "Edges pre-configured in this template.",
+            "items": {
+              "$ref": "#/components/schemas/Edge"
+            }
+          }
+        },
+        "required": ["id", "title", "nodes", "edges"]
       },
       "Edge": {
         "type": "object",
@@ -1306,70 +1660,176 @@
           "output_endpoint_id"
         ]
       },
-      "IotEndpoint": {
-        "type": "object",
-        "description": "Input or output endpoint",
-        "allOf": [
-          {
-            "type": "object",
-            "properties": {
-              "id": {
-                "type": "integer",
-                "description": "Endpoint ID inside user account",
-                "example": 12345,
-                "readOnly": true
-              }
-            },
-            "required": [
-              "id"
-            ]
-          },
-          {
-            "$ref": "#/components/schemas/IotEndpointDraft"
-          }
-        ]
+      "IotEndpointStatus": {
+        "type": "string",
+        "description": "Endpoint connection status.",
+        "enum": ["active", "waiting_reconnect", "suspend", "disabled"],
+        "example": "active"
       },
-      "IotEndpointDraft": {
+      "IotEndpointResponse": {
         "type": "object",
-        "description": "Input or output endpoint draft (for creation)",
+        "description": "Trimmed endpoint representation returned by the endpoint/list endpoint.",
         "properties": {
-          "user_id": {
+          "id": {
             "type": "integer",
-            "description": "Master user ID",
-            "example": 8
+            "description": "Endpoint ID inside user account",
+            "readOnly": true,
+            "example": 12345
+          },
+          "title": {
+            "type": "string",
+            "description": "Endpoint title",
+            "readOnly": true,
+            "example": "MQTT Endpoint"
           },
           "type": {
             "type": "string",
-            "description": "Endpoint type. One of: 'input_default', 'output_default', 'output_mqtt_client'.",
+            "description": "Endpoint type",
+            "readOnly": true,
+            "example": "output_mqtt_client"
+          },
+          "description": {
+            "type": ["string", "null"],
+            "description": "Endpoint description",
+            "readOnly": true,
+            "example": null
+          }
+        }
+      },
+      "IotDefaultEndpointDraft": {
+        "type": "object",
+        "description": "Navixy platform (output_default) endpoint — create/update payload.",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["output_default"],
+            "description": "Endpoint type. Always 'output_default' for this subtype.",
+            "example": "output_default"
+          },
+          "title": {
+            "type": "string",
+            "description": "Endpoint title",
+            "example": "Navixy Endpoint"
+          },
+          "status": {
+            "$ref": "#/components/schemas/IotEndpointStatus"
+          },
+          "description": {
+            "type": ["string", "null"],
+            "description": "Endpoint description (optional, max 4000 characters).",
+            "maxLength": 4000,
+            "example": null
+          }
+        },
+        "required": ["type", "title", "status"]
+      },
+      "IotMqttEndpointDraft": {
+        "type": "object",
+        "description": "MQTT client (output_mqtt_client) endpoint — create/update payload.",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["output_mqtt_client"],
+            "description": "Endpoint type. Always 'output_mqtt_client' for this subtype.",
             "example": "output_mqtt_client"
           },
           "title": {
             "type": "string",
+            "description": "Endpoint title",
             "example": "MQTT Endpoint Client Properties"
           },
           "status": {
-            "type": "string",
-            "description": "Endpoint status. One of: 'active', 'suspend', 'disabled'."
+            "$ref": "#/components/schemas/IotEndpointStatus"
+          },
+          "description": {
+            "type": ["string", "null"],
+            "description": "Endpoint description (optional, max 4000 characters).",
+            "maxLength": 4000,
+            "example": null
           },
           "properties": {
-            "type": "object",
-            "oneOf": [
-              {
-                "$ref": "#/components/schemas/IotEndpointMqttClientProperties"
-              },
-              {
-                "type": "object",
-                "description": "Navixy endpoint - empty object (no properties)",
-                "properties": {}
-              }
-            ]
+            "$ref": "#/components/schemas/IotEndpointMqttClientProperties"
           }
         },
-        "required": [
-          "type",
-          "title",
-          "status"
+        "required": ["type", "title", "status", "properties"]
+      },
+      "IotDefaultEndpoint": {
+        "type": "object",
+        "description": "Navixy platform (output_default) endpoint — full representation including id.",
+        "allOf": [
+          {
+            "type": "object",
+            "required": ["id"],
+            "properties": {
+              "id": {
+                "type": "integer",
+                "description": "Endpoint ID inside user account",
+                "readOnly": true,
+                "example": 12345
+              }
+            }
+          },
+          {
+            "$ref": "#/components/schemas/IotDefaultEndpointDraft"
+          }
         ]
+      },
+      "IotEndpointMqtt": {
+        "type": "object",
+        "description": "MQTT client (output_mqtt_client) endpoint — full representation including id.",
+        "allOf": [
+          {
+            "type": "object",
+            "required": ["id"],
+            "properties": {
+              "id": {
+                "type": "integer",
+                "description": "Endpoint ID inside user account",
+                "readOnly": true,
+                "example": 12345
+              }
+            }
+          },
+          {
+            "$ref": "#/components/schemas/IotMqttEndpointDraft"
+          }
+        ]
+      },
+      "IotEndpoint": {
+        "description": "Output endpoint — full representation. Use the type field to determine which subtype applies.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/IotDefaultEndpoint"
+          },
+          {
+            "$ref": "#/components/schemas/IotEndpointMqtt"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "output_default": "#/components/schemas/IotDefaultEndpoint",
+            "output_mqtt_client": "#/components/schemas/IotEndpointMqtt"
+          }
+        }
+      },
+      "IotEndpointDraft": {
+        "description": "Endpoint for creation. The type field determines the subtype and the required properties.",
+        "oneOf": [
+          {
+            "$ref": "#/components/schemas/IotDefaultEndpointDraft"
+          },
+          {
+            "$ref": "#/components/schemas/IotMqttEndpointDraft"
+          }
+        ],
+        "discriminator": {
+          "propertyName": "type",
+          "mapping": {
+            "output_default": "#/components/schemas/IotDefaultEndpointDraft",
+            "output_mqtt_client": "#/components/schemas/IotMqttEndpointDraft"
+          }
+        }
       },
       "IotEndpointMqttClientProperties": {
         "type": "object",
@@ -1445,6 +1905,73 @@
           "use_ssl",
           "mqtt_auth"
         ]
+      },
+      "IotLogicFlowDeviceMapping": {
+        "type": "object",
+        "description": "A single device-to-flow assignment record.",
+        "properties": {
+          "device_title": {
+            "type": "string",
+            "description": "Device name",
+            "readOnly": true,
+            "example": "Emulator"
+          },
+          "model_code": {
+            "type": "string",
+            "description": "Device model code",
+            "readOnly": true,
+            "example": "navixy_ngp"
+          },
+          "device_id": {
+            "type": "integer",
+            "description": "Device ID",
+            "readOnly": true,
+            "example": 123456789
+          },
+          "flow_id": {
+            "type": "integer",
+            "description": "ID of the flow this device is assigned to",
+            "readOnly": true,
+            "example": 1
+          },
+          "flow_title": {
+            "type": "string",
+            "description": "Name of the flow",
+            "readOnly": true,
+            "example": "Default flow"
+          },
+          "node_id": {
+            "type": "integer",
+            "description": "ID of the Data Source node within the flow that ingests this device",
+            "readOnly": true,
+            "example": 1
+          },
+          "node_title": {
+            "type": "string",
+            "description": "Title of the Data Source node",
+            "readOnly": true,
+            "example": "Source node"
+          }
+        }
+      },
+      "TrackerAttribute": {
+        "type": "object",
+        "description": "A data attribute (parameter) available from a tracker/device. Used by the flow editor to discover which fields can be referenced in node expressions.",
+        "properties": {
+          "name": {
+            "type": "string",
+            "description": "Attribute name as used in flow expressions.",
+            "readOnly": true,
+            "example": "temperature"
+          },
+          "type": {
+            "type": "string",
+            "description": "Data type of the attribute (e.g. 'double', 'integer', 'boolean', 'string').",
+            "readOnly": true,
+            "example": "double"
+          }
+        },
+        "required": ["name", "type"]
       }
     }
   },

--- a/docs/resources/api-reference/IoT_Logic.json
+++ b/docs/resources/api-reference/IoT_Logic.json
@@ -52,7 +52,10 @@
                     "description": "The flow definition, wrapped in this \"flow\" key as required by the create/update endpoints. Export/import operations do not use this envelope — they accept the flow object directly.",
                     "$ref": "#/components/schemas/FlowDraft"
                   }
-                }
+                },
+                "required": [
+                  "flow"
+                ]
               }
             }
           }
@@ -189,14 +192,7 @@
         },
         "responses": {
           "200": {
-            "description": "Successful response to delete a flow",
-            "content": {
-              "application/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/Success"
-                }
-              }
-            }
+            "$ref": "#/components/responses/OK"
           },
           "default": {
             "$ref": "#/components/responses/ResponseError"
@@ -960,17 +956,6 @@
       }
     },
     "schemas": {
-      "Success": {
-        "type": "object",
-        "properties": {
-          "success": {
-            "type": "boolean",
-            "description": "`true` if request finished successfully, otherwise `false`",
-            "readOnly": true,
-            "example": true
-          }
-        }
-      },
       "FlowId": {
         "type": "object",
         "required": [
@@ -997,7 +982,6 @@
           "description": {
             "type": ["string", "null"],
             "description": "Flow description (optional)",
-            "readOnly": true,
             "example": null
           },
           "enabled": {
@@ -1008,7 +992,6 @@
           "default_flow": {
             "type": "boolean",
             "description": "Whether this is the default flow",
-            "readOnly": true,
             "example": false
           },
           "nodes": {
@@ -1042,7 +1025,7 @@
       },
       "FlowExport": {
         "type": "object",
-        "description": "Portable flow structure for export/import (download/upload) operations. Unlike FlowDraft, which must be wrapped in a {\"flow\": ...} envelope when calling the create/update endpoints, FlowExport is used as the direct request/response payload — no wrapper. Runtime and identity fields (enabled, id) are not defined here: Flow is imported in 'enabled' state by default and 'id' is assigned dinamically.",
+        "description": "Portable flow structure for export/import (download/upload) operations. Unlike FlowDraft, which must be wrapped in a {\"flow\": ...} envelope when calling the create/update endpoints, FlowExport is used as the direct request/response payload — no wrapper. Runtime and identity fields (enabled, id) are not defined here: Flow is imported in 'enabled' state by default and 'id' is assigned dynamically.",
         "required": ["title", "nodes", "edges"],
         "properties": {
           "title": {


### PR DESCRIPTION
## What changed

### Correctness fixes
- **`flow/update` response** now returns `{success, id}` — the backend always returns the updated flow's ID; the spec was claiming `{success}` only
- **`flow/list` items** now use the full `IotFlowInfo` shape (`id`, `title`, `description`, `enabled`, `default_flow`, `modified`, `devices_count`) — the spec was documenting `{id, title}` only; description updated to match
- **`endpoint/list` items** now use the trimmed `IotEndpointResponse` (`id`, `title`, `type`, `description`) — the spec was incorrectly referencing the full `IotEndpoint` shape including MQTT properties that the backend does not return from this endpoint; description updated to match
- **`sources/mapping/list` response** replaced an inline JSON example with a proper typed schema (`IotLogicFlowDeviceMapping` items wrapped in `{success, list, count}`)
- **`IotEndpoint` / `IotEndpointDraft` polymorphism** restructured as discriminated unions on the top-level `type` field; previously the discriminator was incorrectly nested inside `properties`
- **`IotEndpointStatus`** defined as an enum (`active`, `waiting_reconnect`, `suspend`, `disabled`) and referenced from endpoint schemas — was an untyped string before
- **`IotEndpointDraft`** cleaned up: `user_id` removed (field is `@JsonIgnore` on the backend), `description` added (nullable, max 4000 chars)
- **`flowCreate` request body** now declares `flow` as required, matching the backend `@NotNull` constraint
- **`FlowDraft.description` and `FlowDraft.default_flow`** had `readOnly: true` removed — both fields are writable on create/update
- **`flowDelete` response** unified to use the shared `OK` response component; the now-redundant `Success` schema removed
- **Typo** fixed in `FlowExport` description: "dinamically" → "dynamically"

### Missing endpoints added (5)
All documented as GET with query parameters, consistent with existing read operations in the spec:

| Endpoint | Purpose |
|---|---|
| `GET flow/schema` | Returns the server-side JSON Schema for validating flow objects before submission |
| `GET flow/template/read` | Retrieves a single system-provided flow template by ID |
| `GET flow/template/list` | Lists all available flow templates with their node/edge graphs |
| `GET flow/sources/list` | Returns device IDs feeding a specific flow (`flow_id=0` = default flow) |
| `GET flow/sources/attribute/list` | Returns telemetry attributes available from specified devices, for authoring node expressions |

### New schemas (10)
`IotFlowInfo`, `IotFlowTemplate`, `IotEndpointStatus`, `IotEndpointResponse`, `IotDefaultEndpointDraft`, `IotMqttEndpointDraft`, `IotDefaultEndpoint`, `IotEndpointMqtt`, `IotLogicFlowDeviceMapping`, `TrackerAttribute`

### Tags
Consolidated to `Flow` and `Node` only. All paths under `/iot/logic/flow/` tagged `Flow`; IotEndpoint CRUD tagged `Node`. Tag descriptions updated to state their exact scope.