### PR TITLE
Fix flowTemplateList and flowSourcesAttributeList spec correctness

### DIFF
--- a/docs/resources/api-reference/IoT_Logic.json
+++ b/docs/resources/api-reference/IoT_Logic.json
@@ -1972,18 +1972,6 @@
             "readOnly": true,
             "example": true
           },
-          "indexed": {
-            "type": "boolean",
-            "description": "Present and `true` when the attribute supports a numeric index suffix (e.g. `temperature_0`, `temperature_1`). Omitted when false.",
-            "readOnly": true,
-            "example": true
-          },
-          "max_index": {
-            "type": "integer",
-            "description": "Highest observed index for an indexed attribute. Omitted when 0.",
-            "readOnly": true,
-            "example": 3
-          },
           "received": {
             "type": "boolean",
             "description": "Present and `true` when this attribute has been observed in actual device data received by the server. Omitted when false.",

--- a/docs/resources/api-reference/IoT_Logic.json
+++ b/docs/resources/api-reference/IoT_Logic.json
@@ -749,7 +749,6 @@
           {
             "name": "source_ids",
             "in": "query",
-            "required": false,
             "style": "form",
             "explode": true,
             "schema": {

--- a/docs/resources/api-reference/IoT_Logic.json
+++ b/docs/resources/api-reference/IoT_Logic.json
@@ -785,6 +785,7 @@
                 "type": "integer"
               },
               "minItems": 1,
+              "maxItems": 25000,
               "description": "Device source IDs to query attributes for. If omitted, returns attributes for all trackers in the account.",
               "example": [123456, 789012]
             }

--- a/docs/resources/api-reference/IoT_Logic.json
+++ b/docs/resources/api-reference/IoT_Logic.json
@@ -749,6 +749,7 @@
           {
             "name": "source_ids",
             "in": "query",
+            "required": true,
             "style": "form",
             "explode": true,
             "schema": {
@@ -757,7 +758,7 @@
                 "type": "integer"
               },
               "minItems": 1,
-              "description": "Device source IDs to query attributes for. If omitted, returns attributes for all trackers in the account.",
+              "description": "Device source IDs to query attributes for.",
               "example": [123456, 789012]
             }
           },
@@ -1116,8 +1117,7 @@
             "example": "Basic processing flow"
           },
           "description": {
-            "type": "string",
-            "nullable": true,
+            "type": ["string", "null"],
             "description": "Template description",
             "example": "A simple flow for standard telemetry processing."
           },

--- a/docs/resources/api-reference/IoT_Logic.json
+++ b/docs/resources/api-reference/IoT_Logic.json
@@ -682,6 +682,12 @@
                             "description": "Translated template description. Supports Markdown.",
                             "readOnly": true,
                             "example": "Monitors GPS signal quality and schedules a device reboot if signal is poor."
+                          },
+                          "icon": {
+                            "type": "string",
+                            "description": "Optional icon key for the template. Omitted when not set.",
+                            "readOnly": true,
+                            "example": "healthcheck"
                           }
                         },
                         "required": ["id", "title"]

--- a/docs/resources/api-reference/IoT_Logic.json
+++ b/docs/resources/api-reference/IoT_Logic.json
@@ -641,7 +641,7 @@
       "get": {
         "tags": ["Flow"],
         "summary": "flowTemplateList",
-        "description": "List all system-provided flow templates available to the user. Each item includes the template ID, translated title, and translated description. To get the full node/edge graph for a specific template, use `flowTemplateRead`. To create a flow from a template, pass its nodes and edges to `flowCreate`.",
+        "description": "List all system-provided flow templates available to the user. Each item includes the template ID, title, description, and the pre-configured node and edge graph. To create a flow from a template, pass the template's nodes and edges to `flowCreate`.",
         "operationId": "flowTemplateList",
         "responses": {
           "200": {
@@ -662,29 +662,7 @@
                       "description": "Available flow templates",
                       "readOnly": true,
                       "items": {
-                        "type": "object",
-                        "description": "Flow template summary. Titles and descriptions are server-translated according to the request locale.",
-                        "properties": {
-                          "id": {
-                            "type": "integer",
-                            "description": "Template ID",
-                            "readOnly": true,
-                            "example": 1
-                          },
-                          "title": {
-                            "type": "string",
-                            "description": "Translated template name",
-                            "readOnly": true,
-                            "example": "Device healthcheck and reboot"
-                          },
-                          "description": {
-                            "type": ["string", "null"],
-                            "description": "Translated template description. Supports Markdown.",
-                            "readOnly": true,
-                            "example": "Monitors GPS signal quality and schedules a device reboot if signal is poor."
-                          }
-                        },
-                        "required": ["id", "title"]
+                        "$ref": "#/components/schemas/IotFlowTemplate"
                       }
                     }
                   }
@@ -765,13 +743,13 @@
       "get": {
         "tags": ["Flow"],
         "summary": "flowSourcesAttributeList",
-        "description": "Return the telemetry attributes available from the specified devices, for use when authoring expressions in Initiate Attributes or Logic nodes. If `source_ids` is omitted, returns attributes for all trackers in the account. Set `include_only_iot_flow_attributes=true` to return only attributes that IoT Logic flows have computed and emitted; omit or set to `false` to return all attributes including raw device parameters.",
+        "description": "Return the telemetry attributes available from the specified devices, for use when authoring expressions in Initiate Attributes or Logic nodes. Pass one or more `source_ids` as repeated query parameters. Set `include_only_iot_flow_attributes=true` to return only attributes that IoT Logic flows have computed and emitted; set it to `false` to return all attributes including raw device parameters.",
         "operationId": "flowSourcesAttributeList",
         "parameters": [
           {
             "name": "source_ids",
             "in": "query",
-            "required": false,
+            "required": true,
             "style": "form",
             "explode": true,
             "schema": {
@@ -780,18 +758,17 @@
                 "type": "integer"
               },
               "minItems": 1,
-              "description": "Device source IDs to query attributes for. If omitted, returns attributes for all trackers in the account.",
+              "description": "Device source IDs to query attributes for.",
               "example": [123456, 789012]
             }
           },
           {
             "name": "include_only_iot_flow_attributes",
             "in": "query",
-            "required": false,
+            "required": true,
             "schema": {
               "type": "boolean",
-              "default": false,
-              "description": "When true, returns only IoT Logic flow-emitted attributes. When false (default), returns all attributes including raw device parameters.",
+              "description": "When true, returns only IoT Logic flow-emitted attributes. When false, returns all attributes including raw device parameters.",
               "example": false
             }
           }

--- a/docs/resources/api-reference/IoT_Logic.json
+++ b/docs/resources/api-reference/IoT_Logic.json
@@ -1958,22 +1958,40 @@
       },
       "TrackerAttribute": {
         "type": "object",
-        "description": "A data attribute (parameter) available from a tracker/device. Used by the flow editor to discover which fields can be referenced in node expressions.",
+        "description": "A telemetry attribute available from a tracker or computed by an IoT Logic flow. Fields other than `name` are omitted when their value is the default (false or 0).",
         "properties": {
           "name": {
             "type": "string",
-            "description": "Attribute name as used in flow expressions.",
+            "description": "Attribute name, as used in flow node expressions.",
             "readOnly": true,
-            "example": "temperature"
+            "example": "avg_speed"
           },
-          "type": {
-            "type": "string",
-            "description": "Data type of the attribute (e.g. 'double', 'integer', 'boolean', 'string').",
+          "in_iot_flow": {
+            "type": "boolean",
+            "description": "Present and `true` when this attribute is computed and emitted by an IoT Logic flow. Omitted when false.",
             "readOnly": true,
-            "example": "double"
+            "example": true
+          },
+          "indexed": {
+            "type": "boolean",
+            "description": "Present and `true` when the attribute supports a numeric index suffix (e.g. `temperature_0`, `temperature_1`). Omitted when false.",
+            "readOnly": true,
+            "example": true
+          },
+          "max_index": {
+            "type": "integer",
+            "description": "Highest observed index for an indexed attribute. Omitted when 0.",
+            "readOnly": true,
+            "example": 3
+          },
+          "received": {
+            "type": "boolean",
+            "description": "Present and `true` when this attribute has been observed in actual device data received by the server. Omitted when false.",
+            "readOnly": true,
+            "example": true
           }
         },
-        "required": ["name", "type"]
+        "required": ["name"]
       }
     }
   },

--- a/docs/resources/api-reference/IoT_Logic.json
+++ b/docs/resources/api-reference/IoT_Logic.json
@@ -1116,7 +1116,8 @@
             "example": "Basic processing flow"
           },
           "description": {
-            "type": ["string", "null"],
+            "type": "string",
+            "nullable": true,
             "description": "Template description",
             "example": "A simple flow for standard telemetry processing."
           },

--- a/docs/resources/api-reference/IoT_Logic.json
+++ b/docs/resources/api-reference/IoT_Logic.json
@@ -749,7 +749,7 @@
           {
             "name": "source_ids",
             "in": "query",
-            "required": true,
+            "required": false,
             "style": "form",
             "explode": true,
             "schema": {
@@ -758,7 +758,7 @@
                 "type": "integer"
               },
               "minItems": 1,
-              "description": "Device source IDs to query attributes for.",
+              "description": "Device source IDs to query attributes for. If omitted, returns attributes for all trackers in the account.",
               "example": [123456, 789012]
             }
           },

--- a/docs/resources/api-reference/IoT_Logic.json
+++ b/docs/resources/api-reference/IoT_Logic.json
@@ -641,7 +641,7 @@
       "get": {
         "tags": ["Flow"],
         "summary": "flowTemplateList",
-        "description": "List all system-provided flow templates available to the user. Each item includes the template ID, title, description, and the pre-configured node and edge graph. To create a flow from a template, pass the template's nodes and edges to `flowCreate`.",
+        "description": "List all system-provided flow templates available to the user. Each item includes the template ID, translated title, and translated description. To get the full node/edge graph for a specific template, use `flowTemplateRead`. To create a flow from a template, pass its nodes and edges to `flowCreate`.",
         "operationId": "flowTemplateList",
         "responses": {
           "200": {
@@ -662,7 +662,29 @@
                       "description": "Available flow templates",
                       "readOnly": true,
                       "items": {
-                        "$ref": "#/components/schemas/IotFlowTemplate"
+                        "type": "object",
+                        "description": "Flow template summary. Titles and descriptions are server-translated according to the request locale.",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "description": "Template ID",
+                            "readOnly": true,
+                            "example": 1
+                          },
+                          "title": {
+                            "type": "string",
+                            "description": "Translated template name",
+                            "readOnly": true,
+                            "example": "Device healthcheck and reboot"
+                          },
+                          "description": {
+                            "type": ["string", "null"],
+                            "description": "Translated template description. Supports Markdown.",
+                            "readOnly": true,
+                            "example": "Monitors GPS signal quality and schedules a device reboot if signal is poor."
+                          }
+                        },
+                        "required": ["id", "title"]
                       }
                     }
                   }
@@ -743,13 +765,13 @@
       "get": {
         "tags": ["Flow"],
         "summary": "flowSourcesAttributeList",
-        "description": "Return the telemetry attributes available from the specified devices, for use when authoring expressions in Initiate Attributes or Logic nodes. Pass one or more `source_ids` as repeated query parameters. Set `include_only_iot_flow_attributes=true` to return only attributes that IoT Logic flows have computed and emitted; set it to `false` to return all attributes including raw device parameters.",
+        "description": "Return the telemetry attributes available from the specified devices, for use when authoring expressions in Initiate Attributes or Logic nodes. If `source_ids` is omitted, returns attributes for all trackers in the account. Set `include_only_iot_flow_attributes=true` to return only attributes that IoT Logic flows have computed and emitted; omit or set to `false` to return all attributes including raw device parameters.",
         "operationId": "flowSourcesAttributeList",
         "parameters": [
           {
             "name": "source_ids",
             "in": "query",
-            "required": true,
+            "required": false,
             "style": "form",
             "explode": true,
             "schema": {
@@ -758,17 +780,18 @@
                 "type": "integer"
               },
               "minItems": 1,
-              "description": "Device source IDs to query attributes for.",
+              "description": "Device source IDs to query attributes for. If omitted, returns attributes for all trackers in the account.",
               "example": [123456, 789012]
             }
           },
           {
             "name": "include_only_iot_flow_attributes",
             "in": "query",
-            "required": true,
+            "required": false,
             "schema": {
               "type": "boolean",
-              "description": "When true, returns only IoT Logic flow-emitted attributes. When false, returns all attributes including raw device parameters.",
+              "default": false,
+              "description": "When true, returns only IoT Logic flow-emitted attributes. When false (default), returns all attributes including raw device parameters.",
               "example": false
             }
           }

--- a/docs/resources/api-reference/IoT_Logic.json
+++ b/docs/resources/api-reference/IoT_Logic.json
@@ -641,7 +641,7 @@
       "get": {
         "tags": ["Flow"],
         "summary": "flowTemplateList",
-        "description": "List all system-provided flow templates available to the user. Each item includes the template ID, title, description, and the pre-configured node and edge graph. To create a flow from a template, pass the template's nodes and edges to `flowCreate`.",
+        "description": "List all system-provided flow templates available to the user. Each item includes the template ID, translated title, and translated description. To get the full node/edge graph for a specific template, use `flowTemplateRead`. To create a flow from a template, pass its nodes and edges to `flowCreate`.",
         "operationId": "flowTemplateList",
         "responses": {
           "200": {
@@ -662,7 +662,29 @@
                       "description": "Available flow templates",
                       "readOnly": true,
                       "items": {
-                        "$ref": "#/components/schemas/IotFlowTemplate"
+                        "type": "object",
+                        "description": "Flow template summary. Titles and descriptions are server-translated according to the request locale.",
+                        "properties": {
+                          "id": {
+                            "type": "integer",
+                            "description": "Template ID",
+                            "readOnly": true,
+                            "example": 1
+                          },
+                          "title": {
+                            "type": "string",
+                            "description": "Translated template name",
+                            "readOnly": true,
+                            "example": "Device healthcheck and reboot"
+                          },
+                          "description": {
+                            "type": ["string", "null"],
+                            "description": "Translated template description. Supports Markdown.",
+                            "readOnly": true,
+                            "example": "Monitors GPS signal quality and schedules a device reboot if signal is poor."
+                          }
+                        },
+                        "required": ["id", "title"]
                       }
                     }
                   }
@@ -743,13 +765,12 @@
       "get": {
         "tags": ["Flow"],
         "summary": "flowSourcesAttributeList",
-        "description": "Return the telemetry attributes available from the specified devices, for use when authoring expressions in Initiate Attributes or Logic nodes. Pass one or more `source_ids` as repeated query parameters. Set `include_only_iot_flow_attributes=true` to return only attributes that IoT Logic flows have computed and emitted; set it to `false` to return all attributes including raw device parameters.",
+        "description": "Return the telemetry attributes available from the specified devices, for use when authoring expressions in Initiate Attributes or Logic nodes. If `source_ids` is omitted, returns attributes for all trackers in the account. Set `include_only_iot_flow_attributes=true` to return only attributes that IoT Logic flows have computed and emitted; omit or set to `false` to return all attributes including raw device parameters.",
         "operationId": "flowSourcesAttributeList",
         "parameters": [
           {
             "name": "source_ids",
             "in": "query",
-            "required": true,
             "style": "form",
             "explode": true,
             "schema": {
@@ -758,17 +779,17 @@
                 "type": "integer"
               },
               "minItems": 1,
-              "description": "Device source IDs to query attributes for.",
+              "description": "Device source IDs to query attributes for. If omitted, returns attributes for all trackers in the account.",
               "example": [123456, 789012]
             }
           },
           {
             "name": "include_only_iot_flow_attributes",
             "in": "query",
-            "required": true,
             "schema": {
               "type": "boolean",
-              "description": "When true, returns only IoT Logic flow-emitted attributes. When false, returns all attributes including raw device parameters.",
+              "default": false,
+              "description": "When true, returns only IoT Logic flow-emitted attributes. When false (default), returns all attributes including raw device parameters.",
               "example": false
             }
           }

--- a/docs/resources/api-reference/IoT_Logic.json
+++ b/docs/resources/api-reference/IoT_Logic.json
@@ -768,39 +768,38 @@
       }
     },
     "/iot/logic/flow/sources/attribute/list": {
-      "get": {
+      "post": {
         "tags": ["Flow"],
         "summary": "flowSourcesAttributeList",
         "description": "Return the telemetry attributes available from the specified devices, for use when authoring expressions in Initiate Attributes or Logic nodes. If `source_ids` is omitted, returns attributes for all trackers in the account. Set `include_only_iot_flow_attributes=true` to return only attributes that IoT Logic flows have computed and emitted; omit or set to `false` to return all attributes including raw device parameters.",
         "operationId": "flowSourcesAttributeList",
-        "parameters": [
-          {
-            "name": "source_ids",
-            "in": "query",
-            "style": "form",
-            "explode": true,
-            "schema": {
-              "type": "array",
-              "items": {
-                "type": "integer"
-              },
-              "minItems": 1,
-              "maxItems": 25000,
-              "description": "Device source IDs to query attributes for. If omitted, returns attributes for all trackers in the account.",
-              "example": [123456, 789012]
-            }
-          },
-          {
-            "name": "include_only_iot_flow_attributes",
-            "in": "query",
-            "schema": {
-              "type": "boolean",
-              "default": false,
-              "description": "When true, returns only IoT Logic flow-emitted attributes. When false (default), returns all attributes including raw device parameters.",
-              "example": false
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "source_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "integer"
+                    },
+                    "minItems": 1,
+                    "maxItems": 25000,
+                    "description": "Device source IDs to query attributes for. If omitted, returns attributes for all trackers in the account.",
+                    "example": [123456, 789012]
+                  },
+                  "include_only_iot_flow_attributes": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "When true, returns only IoT Logic flow-emitted attributes. When false (default), returns all attributes including raw device parameters.",
+                    "example": false
+                  }
+                }
+              }
             }
           }
-        ],
+        },
         "responses": {
           "200": {
             "description": "Successful response",

--- a/docs/resources/api-reference/IoT_Logic.json
+++ b/docs/resources/api-reference/IoT_Logic.json
@@ -678,7 +678,7 @@
                             "example": "Device healthcheck and reboot"
                           },
                           "description": {
-                            "type": ["string", "null"],
+                            "type": "string",
                             "description": "Translated template description. Supports Markdown.",
                             "readOnly": true,
                             "example": "Monitors GPS signal quality and schedules a device reboot if signal is poor."


### PR DESCRIPTION
## Summary

- **`flowTemplateList` response schema** — replaced the `$ref: IotFlowTemplate` (which incorrectly implied `nodes` and `edges` are returned) with a lightweight inline object containing only the fields actually returned: `id`, `title`, `description`, and the newly documented `icon`. Titles and descriptions are server-translated; updated endpoint description to reflect this and to point to `flowTemplateRead` for the full node/edge graph.

- **`flowSourcesAttributeList` method change** — corrected from `GET` with query parameters to `POST` with a JSON request body. The Navixy framework deserializes parameters from the request body; passing `source_ids` as a query string delivers it as a string rather than `Set<Integer>`, causing runtime errors. Both parameters (`source_ids`, `include_only_iot_flow_attributes`) are now optional, `source_ids` is bounded at 25 000 items (`maxItems`), and `include_only_iot_flow_attributes` defaults to `false`.

- **`TrackerAttribute` schema** — replaced the stale `name + type` definition with the actual `AttributeItem` record fields: `name` (required), `in_iot_flow`, and `received`. Non-name fields use `@JsonInclude(NON_DEFAULT)` and are omitted when false; verified against a real API response.

## Test plan

- [x] Open the GitBook API reference and confirm all 14 paths are visible
- [x] Verify `flowTemplateList` response model shows `id`, `title`, `description`, `icon` — no `nodes`/`edges`
- [x] Verify `flowSourcesAttributeList` shows as POST with a request body (not query parameters)
- [x] Verify `TrackerAttribute` model shows `name`, `in_iot_flow`, `received` only

🤖 Generated with [Claude Code](https://claude.com/claude-code)